### PR TITLE
new contract deploy for testing

### DIFF
--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -40,7 +40,7 @@ export const CONFIG = {
       WRAPPED_NATIVE_TOKEN:
         '0xc778417E063141139Fce010982780140Aa0cD5Ab'.toLowerCase(),
       INVOICE_FACTORY:
-        '0x09eBeE5BBC4D3bcB919b19a12EeD711c4748EA60'.toLowerCase(),
+        '0x514E340B9F4BC385d875C1F8cbC2B52b3B20a26A'.toLowerCase(),
       RESOLVERS: {
         ['0x1206b51217271FC3ffCa57d0678121983ce0390E'.toLowerCase()]: {
           name: 'LexDAO',

--- a/packages/subgraph/src/config/rinkeby.json
+++ b/packages/subgraph/src/config/rinkeby.json
@@ -3,8 +3,8 @@
   "factories": [
     {
       "factoryName": "Version06",
-      "startBlock": "11101007",
-      "address": "0x09eBeE5BBC4D3bcB919b19a12EeD711c4748EA60"
+      "startBlock": "11116506",
+      "address": "0x514E340B9F4BC385d875C1F8cbC2B52b3B20a26A"
     }
   ]
 }


### PR DESCRIPTION
Deployed a new factory contract for keeping new/old schema subgraphs separate. This prevents an old schema invoice from breaking a new schema subgraph during testing and vice versa.