### PR TITLE
paynow deploy script and implementation tracking in deployments/

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -16,6 +16,7 @@
     "test-escrow": "hardhat test ./test/SmartInvoiceEscrow.js",
     "escrow-add-goerli": "hardhat run scripts/add-escrow.js --network goerli",
     "escrow-add-local": "hardhat run scripts/add-escrow.js --network localhost",
+    "instant-add-local": "hardhat run scripts/add-instant.js --network localhost",
     "deploy-local": "hardhat run scripts/deploy-factory.js --network localhost",
     "deploy-kovan": "hardhat run scripts/deploy-factory.js --network kovan",
     "deploy-mainnet": "hardhat run scripts/deploy-factory.js --network mainnet",

--- a/packages/contracts/scripts/add-instant.js
+++ b/packages/contracts/scripts/add-instant.js
@@ -29,7 +29,7 @@ const networkCurrency = {
 
 const BLOCKSCOUT_CHAIN_IDS = [77, 100];
 
-const escrowType = ethers.utils.formatBytes32String("escrow");
+const instantType = ethers.utils.formatBytes32String("instant");
 
 async function main() {
   const [deployer] = await ethers.getSigners();
@@ -55,24 +55,24 @@ async function main() {
     networkCurrency[chainId],
   );
 
-  const SmartInvoiceEscrow = await ethers.getContractFactory(
-    "SmartInvoiceEscrow",
+  const SmartInvoiceInstant = await ethers.getContractFactory(
+    "SmartInvoiceInstant",
   );
-  const smartInvoiceEscrow = await SmartInvoiceEscrow.deploy();
-  await smartInvoiceEscrow.deployed();
-  console.log("Deployed Implementation Address:", smartInvoiceEscrow.address);
+  const smartInvoiceInstant = await SmartInvoiceInstant.deploy();
+  await smartInvoiceInstant.deployed();
+  console.log("Deployed Implementation Address:", smartInvoiceInstant.address);
 
-  await smartInvoiceEscrow.initLock();
+  await smartInvoiceInstant.initLock();
 
   const implementationReceipt = await factory
     .connect(deployer)
-    .addImplementation(escrowType, smartInvoiceEscrow.address);
+    .addImplementation(instantType, smartInvoiceInstant.address);
 
   await implementationReceipt.wait();
 
-  const version = await factory.currentVersions(escrowType);
+  const version = await factory.currentVersions(instantType);
   const implementationAdded = await factory.implementations(
-    escrowType,
+    instantType,
     version,
   );
 
@@ -103,10 +103,10 @@ async function main() {
 
   const deployment = JSON.parse(data);
 
-  if (deployment.implementations.escrow != undefined) {
-    deployment.implementations.escrow.push(smartInvoiceEscrow.address);
+  if (deployment.implementations.instant != undefined) {
+    deployment.implementations.instant.push(smartInvoiceInstant.address);
   } else {
-    deployment.implementations["escrow"] = [smartInvoiceEscrow.address];
+    deployment.implementations["instant"] = [smartInvoiceInstant.address];
   }
 
   fs.writeFileSync(


### PR DESCRIPTION
Deploy script for instant type + updated tracking implementation by invoice type in deployments.

Currently the different types/deploys are separate; this would be a good spot to create a new hh task to take invoice type and network as args and create one deploy tasks for all invoice types and chains. However that seems a tiny amount of tech debt and I'm ok putting that one in the backlog for the moment.