### PR TITLE
Implement Instant Type to ViewInvoice and Dashboard

### DIFF
--- a/packages/dapp/src/components/InvoiceDashboardTable.jsx
+++ b/packages/dapp/src/components/InvoiceDashboardTable.jsx
@@ -12,6 +12,7 @@ import {
   MenuList,
   MenuItem,
   HStack,
+  Badge,
 } from '@chakra-ui/react';
 import React, { useMemo } from 'react';
 import { useTable, useSortBy, usePagination } from 'react-table';
@@ -57,6 +58,35 @@ const InvoiceStatusLabel = ({ invoice, ...props }) => {
   );
 };
 
+const InvoiceBadge = ({ invoice, ...props }) => {
+  const { invoiceType } = invoice;
+  const schemes = {
+    escrow: {
+      bg: 'rgba(128, 63, 248, 0.3)',
+      color: 'rgba(128, 63, 248, 1)',
+    },
+    instant: {
+      bg: 'rgba(248, 174, 63, 0.3)',
+      color: 'rgba(248, 174, 63, 1)',
+    },
+    unknown: {
+      bg: 'rgba(150,150,150,0.3)',
+      color: 'rgba(150,150,150,1)',
+    },
+  };
+
+  return (
+    <Badge
+      backgroundColor={schemes[invoiceType ?? 'unknown'].bg}
+      color={schemes[invoiceType ?? 'unknown'].color}
+      maxW="fit-content"
+      height="fit-content"
+    >
+      {invoiceType ? invoiceType.toUpperCase() : 'UNKNOWN'}
+    </Badge>
+  );
+};
+
 export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
   const data = useMemo(() => {
     const dataArray = [];
@@ -75,13 +105,22 @@ export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
       const details = {
         createdAt: dateTimeToDate(unixToDateTime(invoice.createdAt)),
         projectName: (
-          <Link
-            href={`/invoice/${getHexChainId(invoice.network)}/${
-              invoice.address
-            }/${invoice.invoiceType !== 'escrow' ? invoice.invoiceType : ''}`}
+          <Flex
+            gap={2}
+            width="100%"
+            align="center"
+            justify="space-between"
+            onClick={viewInvoice}
           >
-            {invoice.projectName}
-          </Link>
+            <Link
+              href={`/invoice/${getHexChainId(invoice.network)}/${
+                invoice.address
+              }/${invoice.invoiceType !== 'escrow' ? invoice.invoiceType : ''}`}
+            >
+              {invoice.projectName}
+            </Link>
+            <InvoiceBadge invoice={invoice} />
+          </Flex>
         ),
         amount: formatUnits(invoice.total, decimals),
         currency: (

--- a/packages/dapp/src/components/InvoiceDashboardTable.jsx
+++ b/packages/dapp/src/components/InvoiceDashboardTable.jsx
@@ -29,7 +29,7 @@ import { FilterIcon } from '../icons/FilterIcon';
 
 const InvoiceStatusLabel = ({ invoice, ...props }) => {
   const { funded, label, loading } = useInvoiceStatus(invoice);
-  const { isLocked, terminationTime } = invoice;
+  const { isLocked, terminationTime, invoiceType } = invoice;
   const terminated = terminationTime > Date.now();
   const disputeResolved = label === 'Dispute Resolved';
   return (
@@ -40,6 +40,8 @@ const InvoiceStatusLabel = ({ invoice, ...props }) => {
           : terminated || disputeResolved || label === 'Expired'
           ? '#C2CFE0'
           : isLocked
+          ? '#F7685B'
+          : label === 'Overdue'
           ? '#F7685B'
           : funded
           ? '#2ED47A'

--- a/packages/dapp/src/components/InvoiceDashboardTable.jsx
+++ b/packages/dapp/src/components/InvoiceDashboardTable.jsx
@@ -68,7 +68,9 @@ export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
       );
       const viewInvoice = () =>
         history.push(
-          `/invoice/${getHexChainId(invoice.network)}/${invoice.address}`,
+          `/invoice/${getHexChainId(invoice.network)}/${invoice.address}/${
+            invoice.invoiceType !== 'escrow' ? invoice.invoiceType : ''
+          }`,
         );
       const details = {
         createdAt: dateTimeToDate(unixToDateTime(invoice.createdAt)),
@@ -76,7 +78,7 @@ export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
           <Link
             href={`/invoice/${getHexChainId(invoice.network)}/${
               invoice.address
-            }`}
+            }/${invoice.invoiceType !== 'escrow' ? invoice.invoiceType : ''}`}
           >
             {invoice.projectName}
           </Link>

--- a/packages/dapp/src/components/instant/DepositFunds.jsx
+++ b/packages/dapp/src/components/instant/DepositFunds.jsx
@@ -359,7 +359,10 @@ export const DepositFunds = ({
                   >
                     <Heading fontSize={12}>{`${t}%`}</Heading>
                     <Text>
-                      {(utils.formatUnits(total, decimals) * t) / 100}
+                      {utils.formatUnits(
+                        BigNumber.from(total).mul(t).div(100),
+                        decimals,
+                      )}
                     </Text>
                     {/* <Text fontSize={10}>{symbol}</Text> */}
                   </Button>

--- a/packages/dapp/src/components/instant/DepositFunds.jsx
+++ b/packages/dapp/src/components/instant/DepositFunds.jsx
@@ -5,6 +5,8 @@ import {
   Button,
   Checkbox,
   Flex,
+  FormControl,
+  FormLabel,
   Heading,
   Input,
   InputGroup,
@@ -21,9 +23,9 @@ import {
 import { BigNumber, Contract, utils } from 'ethers';
 import React, { useContext, useEffect, useState } from 'react';
 
-import { Web3Context } from '../context/Web3Context';
-import { QuestionIcon } from '../icons/QuestionIcon';
-import { balanceOf } from '../utils/erc20';
+import { Web3Context } from '../../context/Web3Context';
+import { QuestionIcon } from '../../icons/QuestionIcon';
+import { balanceOf } from '../../utils/erc20';
 import {
   getHexChainId,
   getNativeTokenSymbol,
@@ -32,7 +34,7 @@ import {
   getWrappedNativeToken,
   logError,
   calculateResolutionFeePercentage,
-} from '../utils/helpers';
+} from '../../utils/helpers';
 
 const getCheckedStatus = (deposited, amounts) => {
   let sum = BigNumber.from(0);
@@ -153,43 +155,58 @@ export const DepositFunds = ({
         How much will you be depositing today?
       </Text>
       <VStack spacing="0.5rem">
-        <RadioGroup defaultValue={due}>
+        <RadioGroup defaultValue={'full'}>
           <VStack spacing="0.5rem">
-            <Radio
-              value={due}
-              colorScheme="blue"
-              borderColor="lightgrey"
-              size="lg"
-              fontSize="1rem"
-              color="#323C47"
-            >
-              Full amount &nbsp; &nbsp;
-              {utils.formatUnits(due, decimals)} {symbol}
-            </Radio>
-            <Radio
-              value={partialAmount}
-              colorScheme="blue"
-              borderColor="lightgrey"
-              size="lg"
-              fontSize="1rem"
-              color="#323C47"
-            >
-              Partial amount &nbsp; &nbsp;
-              <Input
-                type="number"
-                value={partialAmountInput}
-                onChange={e => {
-                  const v = e.currentTarget.value;
-                  setPartialAmountInput(v);
-                  if (v && !isNaN(Number(v))) {
-                    const p = utils.parseUnits(v, decimals);
-                    setPartialAmount(p);
-                  } else {
-                    setPartialAmount(BigNumber.from(0));
-                  }
-                }}
+            <FormControl display="flex" alignItems="center" gap={2}>
+              <Radio
+                value={'full'}
+                colorScheme="blue"
+                borderColor="lightgrey"
+                size="lg"
+                fontSize="1rem"
+                color="#323C47"
+                id="instant-pay-full"
               />
-            </Radio>
+              <FormLabel htmlFor="instant-pay-full" color="#323C47" mb={0}>
+                Full amount &nbsp; &nbsp;
+                {utils.formatUnits(due, decimals)} {symbol}
+              </FormLabel>
+            </FormControl>
+            <FormControl display="flex" alignItems="flex-start" gap={2}>
+              <Radio
+                value={'partial'}
+                colorScheme="blue"
+                borderColor="lightgrey"
+                size="lg"
+                fontSize="1rem"
+                color="#323C47"
+                id="instant-pay-partial"
+              />
+              <FormLabel htmlFor="instant-pay-partial" color="#323C47" mb={0}>
+                <Text>Partial amount</Text>
+                <Flex align="end" gap={1}>
+                  <Input
+                    type="number"
+                    borderColor="lightgrey"
+                    maxWidth={200}
+                    value={partialAmountInput}
+                    placeholder="Enter a partial amount"
+                    color="#323C47"
+                    onChange={e => {
+                      const v = e.currentTarget.value;
+                      setPartialAmountInput(v);
+                      if (v && !isNaN(Number(v))) {
+                        const p = utils.parseUnits(v, decimals);
+                        setPartialAmount(p);
+                      } else {
+                        setPartialAmount(BigNumber.from(0));
+                      }
+                    }}
+                  />
+                  <Text>{symbol}</Text>
+                </Flex>
+              </FormLabel>
+            </FormControl>
           </VStack>
         </RadioGroup>
         {amounts.map((a, i) => {

--- a/packages/dapp/src/components/instant/DepositFunds.jsx
+++ b/packages/dapp/src/components/instant/DepositFunds.jsx
@@ -1,0 +1,357 @@
+import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  Checkbox,
+  Flex,
+  Heading,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Link,
+  Radio,
+  RadioGroup,
+  Select,
+  Text,
+  Tooltip,
+  useBreakpointValue,
+  VStack,
+} from '@chakra-ui/react';
+import { BigNumber, Contract, utils } from 'ethers';
+import React, { useContext, useEffect, useState } from 'react';
+
+import { Web3Context } from '../context/Web3Context';
+import { QuestionIcon } from '../icons/QuestionIcon';
+import { balanceOf } from '../utils/erc20';
+import {
+  getHexChainId,
+  getNativeTokenSymbol,
+  getTokenInfo,
+  getTxLink,
+  getWrappedNativeToken,
+  logError,
+  calculateResolutionFeePercentage,
+} from '../utils/helpers';
+
+const getCheckedStatus = (deposited, amounts) => {
+  let sum = BigNumber.from(0);
+  return amounts.map(a => {
+    sum = sum.add(a);
+    return deposited.gte(sum);
+  });
+};
+
+const checkedAtIndex = (index, checked) => {
+  return checked.map((_c, i) => i <= index);
+};
+
+export const DepositFunds = ({
+  invoice,
+  deposited,
+  due,
+  tokenData,
+  fulfilled,
+}) => {
+  const { chainId, provider, account } = useContext(Web3Context);
+  const NATIVE_TOKEN_SYMBOL = getNativeTokenSymbol(chainId);
+  const WRAPPED_NATIVE_TOKEN = getWrappedNativeToken(chainId);
+  const { address, token, network, amounts, currentMilestone } = invoice;
+  const [paymentType, setPaymentType] = useState(0);
+  const [amount, setAmount] = useState(BigNumber.from(0));
+  const [amountInput, setAmountInput] = useState('');
+  const { decimals, symbol } = getTokenInfo(chainId, token, tokenData);
+  const [loading, setLoading] = useState(false);
+  const [transaction, setTransaction] = useState();
+  const buttonSize = useBreakpointValue({ base: 'md', md: 'lg' });
+  const [depositError, setDepositError] = useState(false);
+  const [partialAmountInput, setPartialAmountInput] = useState('');
+  const [partialAmount, setPartialAmount] = useState(BigNumber.from(0));
+
+  const deposit = async () => {
+    if (!amount || !provider) return;
+    if (
+      utils.formatUnits(amount, decimals) > utils.formatUnits(balance, decimals)
+    )
+      return setDepositError(true);
+
+    try {
+      setLoading(true);
+      let tx;
+      if (paymentType === 1) {
+        tx = await provider
+          .getSigner()
+          .sendTransaction({ to: address, value: amount });
+      } else {
+        const abi = ['function transfer(address, uint256) public'];
+        const tokenContract = new Contract(token, abi, provider.getSigner());
+        tx = await tokenContract.transfer(address, amount);
+      }
+      setTransaction(tx);
+      await tx.wait();
+      window.location.href = `/invoice/${getHexChainId(network)}/${address}`;
+    } catch (depositError) {
+      setLoading(false);
+      logError({ depositError });
+    }
+  };
+
+  const isWRAPPED = token.toLowerCase() === WRAPPED_NATIVE_TOKEN;
+  const initialStatus = getCheckedStatus(deposited, amounts);
+  const [checked, setChecked] = useState(initialStatus);
+
+  const [balance, setBalance] = useState();
+
+  useEffect(() => {
+    try {
+      if (paymentType === 0) {
+        balanceOf(provider, token, account).then(setBalance);
+      } else {
+        provider.getBalance(account).then(setBalance);
+      }
+    } catch (balanceError) {
+      logError({ balanceError });
+    }
+  }, [paymentType, token, provider, account]);
+
+  useEffect(() => {
+    if (
+      depositError &&
+      utils.formatUnits(balance, decimals) > utils.formatUnits(amount, decimals)
+    ) {
+      setDepositError(false);
+    }
+  }, [depositError, amount, balance]);
+
+  return (
+    <VStack w="100%" spacing="1rem">
+      <Heading
+        fontWeight="bold"
+        mb="1rem"
+        textTransform="uppercase"
+        textAlign="center"
+        color="black"
+      >
+        Pay Invoice
+      </Heading>
+      {/* <Text textAlign="center" fontSize="sm" mb="1rem" color="black">
+        At a minimum, you’ll need to deposit enough to cover the{' '}
+        {currentMilestone === 0 ? 'first' : 'next'} project payment.
+      </Text> */}
+      {depositError ? (
+        <Flex>
+          <Alert bg="none" margin="0 auto" textAlign="center" padding="0">
+            <AlertIcon color="red.500" />
+            <AlertTitle fontSize="sm" color="red.500">
+              Not enough available {symbol} for this deposit
+            </AlertTitle>
+          </Alert>
+        </Flex>
+      ) : null}
+
+      <Text textAlign="center" color="black">
+        How much will you be depositing today?
+      </Text>
+      <VStack spacing="0.5rem">
+        <RadioGroup defaultValue={due}>
+          <VStack spacing="0.5rem">
+            <Radio
+              value={due}
+              colorScheme="blue"
+              borderColor="lightgrey"
+              size="lg"
+              fontSize="1rem"
+              color="#323C47"
+            >
+              Full amount &nbsp; &nbsp;
+              {utils.formatUnits(due, decimals)} {symbol}
+            </Radio>
+            <Radio
+              value={partialAmount}
+              colorScheme="blue"
+              borderColor="lightgrey"
+              size="lg"
+              fontSize="1rem"
+              color="#323C47"
+            >
+              Partial amount &nbsp; &nbsp;
+              <Input
+                type="number"
+                value={partialAmountInput}
+                onChange={e => {
+                  const v = e.currentTarget.value;
+                  setPartialAmountInput(v);
+                  if (v && !isNaN(Number(v))) {
+                    const p = utils.parseUnits(v, decimals);
+                    setPartialAmount(p);
+                  } else {
+                    setPartialAmount(BigNumber.from(0));
+                  }
+                }}
+              />
+            </Radio>
+          </VStack>
+        </RadioGroup>
+        {amounts.map((a, i) => {
+          return (
+            <Checkbox
+              key={i.toString()}
+              isChecked={checked[i]}
+              isDisabled={initialStatus[i]}
+              onChange={e => {
+                const newChecked = e.target.checked
+                  ? checkedAtIndex(i, checked)
+                  : checkedAtIndex(i - 1, checked);
+                const totAmount = amounts.reduce(
+                  (tot, cur, ind) => (newChecked[ind] ? tot.add(cur) : tot),
+                  BigNumber.from(0),
+                );
+                const newAmount = totAmount.gte(deposited)
+                  ? totAmount.sub(deposited)
+                  : BigNumber.from(0);
+
+                setChecked(newChecked);
+                setAmount(newAmount);
+                setAmountInput(utils.formatUnits(newAmount, decimals));
+              }}
+              colorScheme="blue"
+              borderColor="lightgrey"
+              size="lg"
+              fontSize="1rem"
+              color="#323C47"
+            >
+              Payment #{i + 1} &nbsp; &nbsp;
+              {utils.formatUnits(a, decimals)} {symbol}
+            </Checkbox>
+          );
+        })}
+      </VStack>
+
+      <VStack spacing="0.5rem" align="stretch" color="black" mb="1rem">
+        <Flex justify="space-between" w="100%">
+          <Text fontWeight="700">Amount</Text>
+          <Flex>
+            {paymentType === 1 && (
+              <Tooltip
+                label={`Your ${NATIVE_TOKEN_SYMBOL} will be automagically wrapped to ${symbol} tokens`}
+                placement="auto-start"
+              >
+                <QuestionIcon ml="1rem" boxSize="0.75rem" />
+              </Tooltip>
+            )}
+          </Flex>
+        </Flex>
+        <InputGroup>
+          <Input
+            bg="white"
+            color="black"
+            border="1px"
+            type="number"
+            value={amountInput}
+            onChange={e => {
+              const newAmountInput = e.target.value;
+              setAmountInput(newAmountInput);
+              if (newAmountInput) {
+                const newAmount = utils.parseUnits(newAmountInput, decimals);
+                setAmount(newAmount);
+                setChecked(getCheckedStatus(deposited.add(newAmount), amounts));
+              } else {
+                setAmount(BigNumber.from(0));
+                setChecked(initialStatus);
+              }
+            }}
+            placeholder="Amount to Deposit"
+            pr={isWRAPPED ? '6rem' : '3.5rem'}
+          />
+          <InputRightElement w={isWRAPPED ? '6rem' : '3.5rem'}>
+            {isWRAPPED ? (
+              <Select
+                onChange={e => setPaymentType(Number(e.target.value))}
+                value={paymentType}
+                bg="white"
+                color="black"
+                border="1px"
+              >
+                <option value="0">{symbol}</option>
+                <option value="1">{NATIVE_TOKEN_SYMBOL}</option>
+              </Select>
+            ) : (
+              symbol
+            )}
+          </InputRightElement>
+        </InputGroup>
+        {amount.gt(due) && (
+          <Alert bg="none">
+            <AlertIcon color="red.500" />
+            <AlertTitle fontSize="sm">
+              Your deposit is greater than the due amount!
+            </AlertTitle>
+          </Alert>
+        )}
+      </VStack>
+      <Flex color="black" justify="space-between" w="100%" fontSize="sm">
+        {deposited && (
+          <VStack align="flex-start">
+            <Text fontWeight="bold">Total Deposited</Text>
+            <Text>{`${utils.formatUnits(deposited, decimals)} ${symbol}`}</Text>
+          </VStack>
+        )}
+        {deposited && (
+          <VStack align="flex-start">
+            <Text fontWeight="bold">Potential Dispute Fee</Text>
+            <Text>{`${(
+              (utils.formatUnits(amount, decimals) -
+                utils.formatUnits(deposited, decimals)) *
+              calculateResolutionFeePercentage(invoice.resolutionRate)
+            ).toFixed(6)} ${symbol}`}</Text>
+          </VStack>
+        )}
+        {due && (
+          <VStack>
+            <Text fontWeight="bold">Total Due</Text>
+            <Text>{`${utils.formatUnits(due, decimals)} ${symbol}`}</Text>
+          </VStack>
+        )}
+        {balance && (
+          <VStack align="flex-end">
+            <Text fontWeight="bold">Your Balance</Text>
+            <Text>
+              {`${utils.formatUnits(balance, decimals)} ${
+                paymentType === 0 ? symbol : NATIVE_TOKEN_SYMBOL
+              }`}
+            </Text>
+          </VStack>
+        )}
+      </Flex>
+      <Button
+        onClick={deposit}
+        isLoading={loading}
+        _hover={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+        _active={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+        color="white"
+        backgroundColor="blue.1"
+        isDisabled={amount.lte(0)}
+        textTransform="uppercase"
+        size={buttonSize}
+        fontFamily="mono"
+        fontWeight="normal"
+        w="100%"
+      >
+        Deposit
+      </Button>
+      {transaction && (
+        <Text color="black" textAlign="center" fontSize="sm">
+          Follow your transaction{' '}
+          <Link
+            href={getTxLink(chainId, transaction.hash)}
+            isExternal
+            color="blue.1"
+            textDecoration="underline"
+          >
+            here
+          </Link>
+        </Text>
+      )}
+    </VStack>
+  );
+};

--- a/packages/dapp/src/components/instant/WithdrawFunds.jsx
+++ b/packages/dapp/src/components/instant/WithdrawFunds.jsx
@@ -1,0 +1,129 @@
+import {
+  Button,
+  Heading,
+  Link,
+  Text,
+  useBreakpointValue,
+  VStack,
+} from '@chakra-ui/react';
+import { utils } from 'ethers';
+import React, { useContext, useEffect, useState } from 'react';
+
+import { Web3Context } from '../../context/Web3Context';
+import {
+  getHexChainId,
+  getTokenInfo,
+  getTxLink,
+  logError,
+} from '../../utils/helpers';
+import { withdraw } from '../../utils/invoice';
+
+export const WithdrawFunds = ({ invoice, balance, close, tokenData }) => {
+  const [loading, setLoading] = useState(false);
+  const { chainId, provider } = useContext(Web3Context);
+  const { network, address, token } = invoice;
+
+  const { decimals, symbol } = getTokenInfo(chainId, token, tokenData);
+  const [transaction, setTransaction] = useState();
+  const [invalid, setInvalid] = useState(false);
+  const buttonSize = useBreakpointValue({ base: 'md', md: 'lg' });
+
+  useEffect(() => {
+    if (!loading && provider && balance.gte(0)) {
+      setInvalid(false);
+    } else {
+      setInvalid(true);
+    }
+  }, [network, balance, address, provider, close]);
+
+  const send = async () => {
+    try {
+      setLoading(true);
+      const tx = await withdraw(provider, address);
+      setTransaction(tx);
+      await tx.wait();
+      window.location.href = `/invoice/${getHexChainId(
+        network,
+      )}/${address}/instant`;
+      setLoading(false);
+    } catch (withdrawError) {
+      close();
+      logError({ withdrawError });
+    }
+  };
+
+  return (
+    <VStack w="100%" spacing="1rem" color="black">
+      <Heading
+        fontWeight="normal"
+        mb="1rem"
+        textTransform="uppercase"
+        textAlign="center"
+      >
+        Withdraw Funds
+      </Heading>
+      <Text textAlign="center" fontSize="sm" mb="1rem">
+        Follow the instructions in your wallet to withdraw remaining funds from
+        the invoice.
+      </Text>
+      <VStack
+        my="2rem"
+        px="5rem"
+        py="1rem"
+        bg="white"
+        border="1px"
+        borderColor="blue.1"
+        borderRadius="0.5rem"
+      >
+        <Text color="blue.1" fontSize="0.875rem" textAlign="center">
+          Amount To Be Withdrawn
+        </Text>
+        <Text
+          color="blue.dark"
+          fontSize="1rem"
+          fontWeight="bold"
+          textAlign="center"
+        >{`${utils.formatUnits(balance, decimals)} ${symbol}`}</Text>
+      </VStack>
+      {transaction && (
+        <Text color="black" textAlign="center" fontSize="sm">
+          Follow your transaction{' '}
+          <Link
+            href={getTxLink(chainId, transaction.hash)}
+            isExternal
+            color="blue.1"
+            textDecoration="underline"
+          >
+            here
+          </Link>
+        </Text>
+      )}
+      {!invalid && (
+        <Button
+          onClick={send}
+          backgroundColor="blue.1"
+          _hover={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+          _active={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+          color="white"
+          textTransform="uppercase"
+          size={buttonSize}
+          fontFamily="mono"
+          fontWeight="normal"
+          w="100%"
+          isLoading={loading}
+        >
+          Confirm
+        </Button>
+      )}
+      <Link
+        onClick={close}
+        color="blue.1"
+        // size={buttonSize}
+        fontFamily="mono"
+        fontWeight="normal"
+      >
+        Cancel
+      </Link>
+    </VStack>
+  );
+};

--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -51,7 +51,7 @@ export const CONFIG = {
       },
     },
     5: {
-      SUBGRAPH: 'psparacino/goerli-smart-invoices',
+      SUBGRAPH: 'psparacino/test-goerli',
       WRAPPED_NATIVE_TOKEN:
         '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'.toLowerCase(),
       INVOICE_FACTORY:

--- a/packages/dapp/src/context/CreateContext.jsx
+++ b/packages/dapp/src/context/CreateContext.jsx
@@ -223,21 +223,24 @@ export const CreateContextProvider = ({ children }) => {
 
       const factoryAddress = getInvoiceFactoryAddress(chainId);
 
+      let paymentAmounts = [BigNumber.from(0)];
       if (invoiceType === Escrow) {
         const escrowInfo = encodeEscrowData(factoryAddress);
         type = escrowInfo.type;
         data = escrowInfo.data;
+        paymentAmounts = payments;
       } else if (invoiceType === Instant) {
         const instantInfo = encodeInstantData(factoryAddress);
         type = instantInfo.type;
         data = instantInfo.data;
+        paymentAmounts = [paymentDue];
       }
 
       const transaction = await register(
         factoryAddress,
         rpcProvider,
         paymentAddress,
-        payments,
+        paymentAmounts,
         data,
         type,
       ).catch(registerError => {
@@ -258,6 +261,9 @@ export const CreateContextProvider = ({ children }) => {
     paymentToken,
     payments,
     safetyValveDate,
+    deadline,
+    lateFee,
+    lateFeeInterval,
     detailsHash,
     requireVerification,
     step1Valid,

--- a/packages/dapp/src/hooks/useInvoiceStatus.jsx
+++ b/packages/dapp/src/hooks/useInvoiceStatus.jsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useState } from 'react';
 import { Web3Context } from '../context/Web3Context';
 import { balanceOf } from '../utils/erc20';
 import { logError } from '../utils/helpers';
+import { getDeadline, getTotalDue, getTotalFulfilled } from '../utils/invoice';
 
 export const useInvoiceStatus = invoice => {
   const { provider } = useContext(Web3Context);
@@ -24,41 +25,78 @@ export const useInvoiceStatus = invoice => {
         disputes,
         resolutions,
         deposits,
+        invoiceType,
       } = invoice;
-      balanceOf(provider, token, address)
-        .then(balance => {
-          if (Number(currentMilestone) === amounts.length) {
-            if (
-              disputes.length === resolutions.length &&
-              resolutions.length > 0
-            ) {
-              setLabel('Dispute Resolved');
+      if (invoiceType === 'escrow') {
+        balanceOf(provider, token, address)
+          .then(balance => {
+            if (Number(currentMilestone) === amounts.length) {
+              if (
+                disputes.length === resolutions.length &&
+                resolutions.length > 0
+              ) {
+                setLabel('Dispute Resolved');
+              } else {
+                setLabel('Completed');
+              }
             } else {
-              setLabel('Completed');
+              const amount = BigNumber.from(amounts[currentMilestone]);
+              if (deposits.length > 0 && balance < amount) {
+                setFunded(!isLocked);
+                setLabel('Partially Funded');
+              } else if (balance.gte(amount)) {
+                setFunded(!isLocked);
+                setLabel('Funded');
+              } else if (terminationTime <= new Date().getTime() / 1000) {
+                setLabel('Expired');
+              } else {
+                setLabel('Awaiting Deposit');
+              }
+              if (isLocked) {
+                setLabel('In Dispute');
+              }
             }
-          } else {
-            const amount = BigNumber.from(amounts[currentMilestone]);
-            if (deposits.length > 0 && balance < amount) {
-              setFunded(!isLocked);
-              setLabel('Partially Funded');
-            } else if (balance.gte(amount)) {
-              setFunded(!isLocked);
-              setLabel('Funded');
-            } else if (terminationTime <= new Date().getTime() / 1000) {
-              setLabel('Expired');
-            } else {
-              setLabel('Awaiting Deposit');
-            }
-            if (isLocked) {
-              setLabel('In Dispute');
-            }
-          }
 
-          setLoading(false);
-        })
-        .catch(statusError => logError({ statusError }));
+            setLoading(false);
+          })
+          .catch(statusError => logError({ statusError }));
+      } else {
+        fetchInstantInfo(provider, address)
+          .then(info => {
+            if (info.isFulfilled) {
+              setFunded(true);
+              setLabel('Completed');
+            } else {
+              if (deposits.length > 0) {
+                setFunded(true);
+                setLabel('Partially Funded');
+              } else if (info.deadline <= new Date().getTime() / 1000) {
+                setLabel('Overdue');
+              } else {
+                setLabel('Awaiting Deposit');
+              }
+            }
+
+            setLoading(false);
+          })
+          .catch(statusError => logError({ statusError }));
+      }
     }
   }, [invoice, provider]);
+
+  async function fetchInstantInfo(provider, invoiceAddress) {
+    try {
+      const deadline = await getDeadline(provider, invoiceAddress);
+      const fulfilled = await getTotalFulfilled(provider, invoiceAddress);
+      return {
+        deadline,
+        isFulfilled: fulfilled.isFulfilled,
+        fulfilledAmount: fulfilled.amount,
+      };
+    } catch (instantFetchError) {
+      logError({ instantFetchError });
+    }
+  }
 
   return { funded, label, loading };
 };

--- a/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
+++ b/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
@@ -27,7 +27,7 @@ import { Loader } from '../../components/Loader';
 import { LockFunds } from '../../components/LockFunds';
 import { ReleaseFunds } from '../../components/ReleaseFunds';
 import { ResolveFunds } from '../../components/ResolveFunds';
-import { WithdrawFunds } from '../../components/WithdrawFunds';
+import { WithdrawFunds } from '../../components/instant/WithdrawFunds';
 import { AddMilestones } from '../../components/AddMilestones';
 import { VerifyInvoice } from '../../components/VerifyInvoice';
 import { GenerateInvoicePDF } from '../../components/GenerateInvoicePDF';
@@ -219,7 +219,7 @@ export const ViewInstantInvoice = ({
   const isReleasable = balance.gte(amount) && balance.gt(0);
   const isLockable = !isExpired && !isLocked && balance.gt(0);
   const isTippable = fulfilled;
-  const isWithdrawable = balance.gte(amount) && balance.gt(0);
+  const isWithdrawable = balance.gt(0);
 
   const onDeposit = () => {
     setSelected(1);
@@ -443,7 +443,7 @@ export const ViewInstantInvoice = ({
               fontSize="lg"
               mb="1rem"
             >
-              <Text>Paid</Text>
+              <Text>Deposited</Text>
               <Text>{`(${utils.formatUnits(
                 totalFulfilled,
                 decimals,
@@ -468,7 +468,7 @@ export const ViewInstantInvoice = ({
               )} ${symbol}`}</Text>{' '}
             </Flex>
           </Flex>
-          {isClient && (
+          {/* {isClient && (
             <SimpleGrid columns={gridColumns} spacing="1rem" w="100%">
               {isReleasable && (
                 <Button
@@ -505,8 +505,8 @@ export const ViewInstantInvoice = ({
                 {isReleasable ? 'Release' : 'Deposit'}
               </Button>
             </SimpleGrid>
-          )}
-          {!isClient && (
+          )} */}
+          {isClient && (
             <VStack>
               <SimpleGrid columns={isLockable ? 2 : 1} spacing="1rem" w="100%">
                 <Button
@@ -521,6 +521,25 @@ export const ViewInstantInvoice = ({
                   onClick={() => onDeposit()}
                 >
                   Make Payment
+                </Button>
+              </SimpleGrid>
+            </VStack>
+          )}
+          {isProvider && (
+            <VStack>
+              <SimpleGrid columns={1} spacing="1rem" w="100%">
+                <Button
+                  size={buttonSize}
+                  _hover={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+                  _active={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
+                  color="white"
+                  backgroundColor="blue.1"
+                  fontWeight="bold"
+                  fontFamily="mono"
+                  textTransform="uppercase"
+                  onClick={() => onWithdraw()}
+                >
+                  Receive
                 </Button>
               </SimpleGrid>
             </VStack>
@@ -552,14 +571,14 @@ export const ViewInstantInvoice = ({
                   close={() => setModal(false)}
                 />
               )}
-              {modal && selected === 2 && (
+              {/* {modal && selected === 2 && (
                 <ReleaseFunds
                   invoice={invoice}
                   balance={balance}
                   tokenData={tokenData}
                   close={() => setModal(false)}
                 />
-              )}
+              )} */}
               {modal && selected === 4 && (
                 <WithdrawFunds
                   invoice={invoice}

--- a/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
+++ b/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
@@ -545,7 +545,9 @@ export const ViewInstantInvoice = ({
                 <DepositFunds
                   invoice={invoice}
                   deposited={deposited}
-                  due={due}
+                  due={totalDue}
+                  total={total}
+                  fulfilled={fulfilled}
                   tokenData={tokenData}
                   close={() => setModal(false)}
                 />

--- a/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
+++ b/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
@@ -136,22 +136,17 @@ export const ViewInstantInvoice = ({
     terminationTime,
     client,
     provider,
-    resolver,
     currentMilestone,
     amounts,
     total,
     token,
     released,
     isLocked,
-    deposits,
-    releases,
-    disputes,
-    resolutions,
-    verified,
+    deadline,
   } = invoice;
 
   const isClient = account.toLowerCase() === client;
-  const isResolver = account.toLowerCase() === resolver.toLowerCase();
+  const isProvider = account.toLowerCase() === provider;
   const { decimals, symbol, image } = getTokenInfo(
     invoiceChainId,
     token,
@@ -169,17 +164,6 @@ export const ViewInstantInvoice = ({
   );
   const isReleasable = !isLocked && balance.gte(amount) && balance.gt(0);
   const isLockable = !isExpired && !isLocked && balance.gt(0);
-  const dispute =
-    isLocked && disputes.length > 0 ? disputes[disputes.length - 1] : undefined;
-  const resolution =
-    !isLocked && resolutions.length > 0
-      ? resolutions[resolutions.length - 1]
-      : undefined;
-
-  const onLock = () => {
-    setSelected(0);
-    setModal(true);
-  };
 
   const onDeposit = () => {
     setSelected(1);
@@ -187,18 +171,18 @@ export const ViewInstantInvoice = ({
   };
 
   const onRelease = async () => {
-    if (isReleasable && isClient) {
+    if (isReleasable && isProvider) {
       setSelected(2);
       setModal(true);
     }
   };
 
-  const onResolve = async () => {
-    if (isResolver) {
-      setSelected(3);
-      setModal(true);
-    }
-  };
+  // const onTip = async () => {
+  //   if (isTippable) {
+  //     setSelected(3);
+  //     setModal(true);
+  //   }
+  // }
 
   const onWithdraw = async () => {
     if (isExpired && isClient) {
@@ -207,21 +191,14 @@ export const ViewInstantInvoice = ({
     }
   };
 
-  const onAddMilestones = async () => {
-    if (!isLocked & !isExpired) {
-      setSelected(5);
-      setModal(true);
-    }
-  };
-
-  let gridColumns;
-  if (isReleasable && (isLockable || (isExpired && balance.gt(0)))) {
-    gridColumns = { base: 2, sm: 3 };
-  } else if (isLockable || isReleasable || (isExpired && balance.gt(0))) {
-    gridColumns = 2;
-  } else {
-    gridColumns = 1;
-  }
+  let gridColumns = 1;
+  // if (isReleasable && (isLockable || (isExpired && balance.gt(0)))) {
+  //   gridColumns = { base: 2, sm: 3 };
+  // } else if (isLockable || isReleasable || (isExpired && balance.gt(0))) {
+  //   gridColumns = 2;
+  // } else {
+  //   gridColumns = 1;
+  // }
 
   let sum = BigNumber.from(0);
 
@@ -501,14 +478,6 @@ export const ViewInstantInvoice = ({
                 right="0.5rem"
                 color="gray"
               />
-              {modal && selected === 0 && (
-                <LockFunds
-                  invoice={invoice}
-                  balance={balance}
-                  tokenData={tokenData}
-                  close={() => setModal(false)}
-                />
-              )}
               {modal && selected === 1 && (
                 <DepositFunds
                   invoice={invoice}
@@ -526,27 +495,10 @@ export const ViewInstantInvoice = ({
                   close={() => setModal(false)}
                 />
               )}
-              {modal && selected === 3 && (
-                <ResolveFunds
-                  invoice={invoice}
-                  balance={balance}
-                  tokenData={tokenData}
-                  close={() => setModal(false)}
-                />
-              )}
               {modal && selected === 4 && (
                 <WithdrawFunds
                   invoice={invoice}
                   balance={balance}
-                  tokenData={tokenData}
-                  close={() => setModal(false)}
-                />
-              )}
-              {modal && selected === 5 && (
-                <AddMilestones
-                  invoice={invoice}
-                  deposited={deposited}
-                  due={due}
                   tokenData={tokenData}
                   close={() => setModal(false)}
                 />

--- a/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
+++ b/packages/dapp/src/pages/instant/ViewInstantInvoice.jsx
@@ -221,14 +221,14 @@ export const ViewInstantInvoice = ({
 
   const onTip = async () => {
     if (isTippable) {
-      setSelected(3);
+      setSelected(1);
       setModal(true);
     }
   };
 
   const onWithdraw = async () => {
     if (isWithdrawable && isProvider) {
-      setSelected(4);
+      setSelected(2);
       setModal(true);
     }
   };
@@ -445,7 +445,7 @@ export const ViewInstantInvoice = ({
           </Flex>
           {isClient && (
             <VStack>
-              <SimpleGrid columns={1} spacing="1rem" w="100%">
+              <SimpleGrid columns={fulfilled ? 2 : 1} spacing="1rem" w="100%">
                 <Button
                   size={buttonSize}
                   _hover={{ backgroundColor: 'rgba(61, 136, 248, 0.7)' }}
@@ -460,6 +460,29 @@ export const ViewInstantInvoice = ({
                 >
                   {fulfilled ? 'Paid' : 'Make Payment'}
                 </Button>
+                {isTippable && (
+                  <Button
+                    size={buttonSize}
+                    _hover={{
+                      backgroundColor: 'rgba(61, 136, 248, 1)',
+                      color: 'white',
+                    }}
+                    _active={{
+                      backgroundColor: 'rgba(61, 136, 248, 1)',
+                      color: 'white',
+                    }}
+                    color="blue.1"
+                    backgroundColor="white"
+                    borderWidth={1}
+                    borderColor="blue.1"
+                    fontWeight="bold"
+                    fontFamily="mono"
+                    textTransform="uppercase"
+                    onClick={() => onTip()}
+                  >
+                    Add Tip
+                  </Button>
+                )}
               </SimpleGrid>
             </VStack>
           )}
@@ -502,15 +525,19 @@ export const ViewInstantInvoice = ({
               {modal && selected === 1 && (
                 <DepositFunds
                   invoice={invoice}
-                  deposited={deposited}
-                  due={totalDue}
+                  deposited={totalFulfilled}
+                  due={
+                    totalDue.gte(totalFulfilled)
+                      ? totalDue.sub(totalFulfilled)
+                      : 0
+                  }
                   total={total}
                   fulfilled={fulfilled}
                   tokenData={tokenData}
                   close={() => setModal(false)}
                 />
               )}
-              {modal && selected === 4 && (
+              {modal && selected === 2 && (
                 <WithdrawFunds
                   invoice={invoice}
                   balance={balance}

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -174,3 +174,16 @@ export const getLateFee = async (ethersProvider, address) => {
     timeInterval: await contract.lateFeeTimeInterval(),
   };
 };
+
+export const depositTokens = async (
+  ethersProvider,
+  address,
+  tokenAddress,
+  amount,
+) => {
+  const abi = new utils.Interface([
+    'function depositTokens(address _token, uint256 _amount) external',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider.getSigner());
+  return contract.depositTokens(tokenAddress, amount);
+};

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -191,3 +191,16 @@ export const depositTokens = async (
   const contract = new Contract(address, abi, ethersProvider.getSigner());
   return contract.depositTokens(tokenAddress, amount);
 };
+
+export const tipTokens = async (
+  ethersProvider,
+  address,
+  tokenAddress,
+  amount,
+) => {
+  const abi = new utils.Interface([
+    'function tip(address _token, uint256 _amount) external',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider.getSigner());
+  return contract.tip(tokenAddress, amount);
+};

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -150,9 +150,13 @@ export const getTotalDue = async (ethersProvider, address) => {
 export const getTotalFulfilled = async (ethersProvider, address) => {
   const abi = new utils.Interface([
     'function totalFulfilled() public view returns(uint256)',
+    'function fulfilled() public view returns (bool)',
   ]);
   const contract = new Contract(address, abi, ethersProvider);
-  return contract.totalFulfilled();
+  return {
+    amount: await contract.totalFulfilled(),
+    isFulfilled: await contract.fulfilled(),
+  };
 };
 
 export const getDeadline = async (ethersProvider, address) => {

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -137,3 +137,40 @@ export const unixToDateTime = unixTimestamp => {
 
   return humanDateFormat;
 };
+
+// Functions for Instant type
+export const getTotalDue = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function getTotalDue() public view returns(uint256)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider);
+  return contract.getTotalDue();
+};
+
+export const getTotalFulfilled = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function totalFulfilled() public view returns(uint256)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider);
+  return contract.totalFulfilled();
+};
+
+export const getDeadline = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function deadline() public view returns(uint256)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider);
+  return contract.deadline();
+};
+
+export const getLateFee = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function lateFee() public view returns(uint256)',
+    'function lateFeeTimeInterval() public view returns (uint256)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider);
+  return {
+    amount: await contract.lateFee(),
+    timeInterval: await contract.lateFeeTimeInterval(),
+  };
+};


### PR DESCRIPTION
This PR allows users to do the following:
- View their instant and escrow invoices on the dashboard with their own badge. The badges indicate the invoice type.
- View full page of their instant invoice
- Deposit and tip (if paying full remaining amount due) tokens into the invoice, if client
- Withdraw token balance (collect the payment) from the invoice, if provider

Since the subgraph has not fully implemented instant type specific invoice variables, I created new functions in `invoice.js` to query them directly from the contract. I'm expecting this workaround to be temporary and will be changed to just reading from the subgraph to reduce number of RPC calls.

Last thing, I made modified duplicates of `DepositFunds` and `WithdrawFunds` modal components. I believe we should add some of these modifications to the escrow version, too. The biggest mod was in `WithdrawFunds` in which the UI is cleaner and more in theme with the rest of the site. Other part of it was that I changed the UX so when the user clicks on "Withdraw/Receive" button, they will have to the press "confirm" button in the modal before metamask pops up for transaction. 